### PR TITLE
Support for Dark themes

### DIFF
--- a/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigGeneral.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigGeneral.qml
@@ -114,7 +114,7 @@ Item {
             visible: appletVersion
 
             ColumnLayout {
-                Text {
+                Label {
                     text: "Version: " + appletVersion
 
                     Component.onCompleted: {
@@ -137,7 +137,7 @@ Item {
             height: units.gridUnit / 2
         }
         ColumnLayout {
-            Text {
+            Label {
                 text: "Show/Hide widgets above the calendar."
             }
             CheckBox {
@@ -203,10 +203,8 @@ Item {
                 color: palette.text
             }
 
-            Text {
+            Label {
                 text: '<a href="http://doc.qt.io/qt-5/qml-qtqml-qt.html#formatDateTime-method">Time Format Documentation</a>'
-                color: "#8a6d3b"
-                linkColor: "#369"
                 onLinkActivated: Qt.openUrlExternally(link)
                 MouseArea {
                     anchors.fill: parent
@@ -233,7 +231,7 @@ Item {
             }
 
 
-            Text {
+            Label {
                 Layout.maximumWidth: page.width
                 wrapMode: Text.Wrap
                 text: 'The default font for the Breeze theme is Noto Sans which has a large vertical spacing. Try using the Sans Serif font if you find the text too small when adding a second line.'
@@ -270,7 +268,7 @@ Item {
                 }
             }
 
-            Text {
+            Label {
                 Layout.maximumWidth: page.width
                 wrapMode: Text.Wrap
                 text: 'You can also use <b>\'&lt;b&gt;\'ddd\'&lt;\/b&gt;\'</b> or <b>\'&lt;font color=\"#77aaadd\"&gt;\'ddd\'&lt;\/font&gt;\'</b> to style a section. Note the single quotes around the tags are used to bypass the time format.'

--- a/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigWeather.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigWeather.qml
@@ -50,7 +50,7 @@ Item {
                 }
             }
 
-            Text {
+            Label {
                 text: 'Get your city\'s id at <a href="https://openweathermap.org/">https://openweathermap.org/</a>,'
                 onLinkActivated: Qt.openUrlExternally(link)
                 MouseArea {
@@ -59,7 +59,7 @@ Item {
                     cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
                 }
             }
-            Text {
+            Label {
                 text: 'or by searching google with `<a href="https://www.google.ca/search?q=site%3Aopenweathermap.org%2Fcity+toronto">site:openweathermap.org/city</a>`.'
                 onLinkActivated: Qt.openUrlExternally(link)
                 MouseArea {


### PR DESCRIPTION
First, this plasmoid is amazing! I just noticed in the config dialogs you are using text fields, which means by default the text color is _always_ black:

![screenshot_20160502_214617](https://cloud.githubusercontent.com/assets/1096937/14972946/17b71afa-10b0-11e6-8d84-16b411bb3f5d.png)

So I just changed those to Quick.Controls Labels that inherit system colors:

![screenshot_20160502_215314](https://cloud.githubusercontent.com/assets/1096937/14972957/47f6f096-10b0-11e6-9755-1427721309d3.png)

This means dark themes (or any theme) have their specified text / URL colors used.