### PR TITLE
hide calendar & add automatic updates patches

### DIFF
--- a/org.kde.plasma.eventcalendar/package/contents/config/main.xml
+++ b/org.kde.plasma.eventcalendar/package/contents/config/main.xml
@@ -23,6 +23,9 @@
     <entry name="widget_show_timer" type="bool">
       <default>true</default>
     </entry>
+    <entry name="widget_show_calendar" type="bool">
+      <default>true</default>
+    </entry>
     <entry name="timer_sfx_enabled" type="bool">
       <default>true</default>
     </entry>

--- a/org.kde.plasma.eventcalendar/package/contents/config/main.xml
+++ b/org.kde.plasma.eventcalendar/package/contents/config/main.xml
@@ -80,6 +80,9 @@
     <entry name="timer_ends_at" type="UInt">
       <default>0</default>
     </entry>
+    <entry name="update_pollinterval" type="UInt">
+      <default>20</default>
+    </entry>
   </group>
   
   <group name="Calendar">

--- a/org.kde.plasma.eventcalendar/package/contents/ui/PopupView.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/PopupView.qml
@@ -22,7 +22,7 @@ Item {
     property int columnWidth: width / 2
     property int padding: 0
 
-    Layout.minimumWidth: (400 + 10 + 400) * units.devicePixelRatio
+    Layout.minimumWidth: (cfg_widget_show_calendar ? (400 + 10 + 400) : 400) * units.devicePixelRatio
     Layout.preferredWidth: (400 + 10 + 400) * units.devicePixelRatio + padding * 2
     Layout.maximumWidth: plasmoid.screenGeometry.width
 
@@ -36,6 +36,7 @@ Item {
     property bool cfg_widget_show_pin: false
     property bool cfg_widget_show_meteogram: true
     property bool cfg_widget_show_timer: true
+    property bool cfg_widget_show_calendar: true
     property bool cfg_timer_sfx_enabled: true
     property string cfg_timer_sfx_filepath: "/usr/share/sounds/freedesktop/stereo/complete.oga"
     property bool cfg_agenda_scroll_on_select: true
@@ -263,6 +264,7 @@ Item {
 
             MonthView {
                 id: monthView
+                visible: cfg_widget_show_calendar
                 borderOpacity: cfg_month_show_border ? 0.25 : 0
                 showWeekNumbers: cfg_month_show_weeknumbers
                 eventBadgeType: cfg_month_eventbadge_type

--- a/org.kde.plasma.eventcalendar/package/contents/ui/PopupView.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/PopupView.qml
@@ -50,6 +50,7 @@ Item {
     property string cfg_month_eventbadge_type: 'theme'
     property bool cfg_agenda_newevent_remember_calendar: true
     property string cfg_agenda_newevent_last_calendar_id: ''
+    property int cfg_update_pollinterval: 20
     
     property alias agendaListView: agendaView.agendaListView
     property alias today: monthView.today
@@ -343,6 +344,16 @@ Item {
             // agendaView.parseGCalEvents(eventsData);
             // monthView.parseGCalEvents(eventsData);
         }
+        polltimer.start()
+    }
+        
+    Timer {
+        id: polltimer
+        
+        repeat: true
+        triggeredOnStart: true
+        interval: cfg_update_pollinterval * 60000
+        onTriggered: update()
     }
 
     function update() {

--- a/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigCalendar.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigCalendar.qml
@@ -10,6 +10,7 @@ ColumnLayout {
     id: page
     property bool showDebug: false
 
+    property alias cfg_widget_show_calendar: widget_show_calendar.checked
     property alias cfg_month_show_border: month_show_border.checked
     property alias cfg_month_show_weeknumbers: month_show_weeknumbers.checked
     property string cfg_month_eventbadge_type: 'bottomBar'
@@ -22,6 +23,12 @@ ColumnLayout {
         Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
 
+        CheckBox {
+            Layout.fillWidth: true
+            id: widget_show_calendar
+            text: "Show calendar"
+        }
+        
         GroupBox {
             Layout.fillWidth: true
 

--- a/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigGeneral.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/config/ConfigGeneral.qml
@@ -38,6 +38,7 @@ Item {
     property alias cfg_timer_repeats: timer_repeats.checked
     property alias cfg_timer_in_taskbar: timer_in_taskbar.checked
     property alias cfg_timer_ends_at: timer_ends_at.text
+    property alias cfg_update_pollinterval: update_pollinterval.value
 
     property string timeFormat24hour: 'hh:mm'
     property string timeFormat12hour: 'h:mm AP'
@@ -109,6 +110,20 @@ Item {
     ColumnLayout {
         id: pageColumn
         Layout.fillWidth: true
+
+        RowLayout {
+            Label {
+                text: i18n("Polling interval: ")
+            }
+            
+            SpinBox {
+                id: update_pollinterval
+                
+                suffix: i18ncp("Polling interval in minutes", "min", "min", value)
+                minimumValue: 1
+                maximumValue: 90
+            }
+        }
 
         GroupBox {
             Layout.fillWidth: true

--- a/org.kde.plasma.eventcalendar/package/contents/ui/main.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/main.qml
@@ -118,6 +118,7 @@ Item {
         cfg_clock_24h: plasmoid.configuration.clock_24h
         cfg_widget_show_meteogram: plasmoid.configuration.widget_show_meteogram
         cfg_widget_show_timer: plasmoid.configuration.widget_show_timer
+        cfg_widget_show_calendar: plasmoid.configuration.widget_show_calendar
         cfg_timer_sfx_enabled: plasmoid.configuration.timer_sfx_enabled
         cfg_timer_sfx_filepath: plasmoid.configuration.timer_sfx_filepath
         cfg_agenda_weather_show_icon: plasmoid.configuration.agenda_weather_show_icon

--- a/org.kde.plasma.eventcalendar/package/contents/ui/main.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/main.qml
@@ -130,6 +130,7 @@ Item {
         cfg_month_show_border: plasmoid.configuration.month_show_border
         cfg_month_show_weeknumbers: plasmoid.configuration.month_show_weeknumbers
         cfg_month_eventbadge_type: plasmoid.configuration.month_eventbadge_type
+        cfg_update_pollinterval: plasmoid.configuration.update_pollinterval
 
         // If pin is enabled, we need to add some padding around the popup unless
         // * we're a desktop widget (no need)


### PR DESCRIPTION
I wrote two patches for your eventcalendar applet:
1) The first one makes it possible to hide the calendar view (I personally use only the agenda view with the option to show weather icons).
2) The second one adds the possibility of automatic updating the applet over a period of time (polling interval).

If you like them both (or any one of them), please consider merging this pull request to your branch. I am open to any discussion regarding this pull request.

Thank you and best regards.

Sergio (a.k.a TioDuke)