### PR TITLE
DPI Scaling

### DIFF
--- a/org.kde.plasma.eventcalendar/package/contents/ui/AgendaListItem.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/AgendaListItem.qml
@@ -36,7 +36,7 @@ RowLayout {
 
         Column {
             id: itemWeatherColumn
-            width: 50
+            width: 3 * units.gridUnit
             Layout.alignment: Qt.AlignTop
 
             FontIcon {
@@ -97,7 +97,7 @@ RowLayout {
 
         Column {
             id: itemDateColumn
-            width: 50
+            width: 2.5 * units.gridUnit
 
             Text {
                 id: itemDate

--- a/org.kde.plasma.eventcalendar/package/contents/ui/TimerView.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/TimerView.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.0
-import QtQuick.Window 2.2
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles.Plasma 2.0 as Styles
 import QtQuick.Layouts 1.1

--- a/org.kde.plasma.eventcalendar/package/contents/ui/TimerView.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/TimerView.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtQuick.Window 2.2
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles.Plasma 2.0 as Styles
 import QtQuick.Layouts 1.1
@@ -14,7 +15,7 @@ Item {
 
     property int timerSeconds: 0
     property int timerDuration: 0
-    property int defaultTimerWidth: 48
+    property int defaultTimerWidth: 3 * units.gridUnit
     property alias timerRepeats: timerRepeatsButton.isChecked
     property alias timerSfxEnabled: timerSfxEnabledButton.isChecked
 


### PR DESCRIPTION
Event calendars agenda and timer could not be used on HDPI (4K) display, so I made those two minor fixes.
Instead of hard-coding width in pixels, I have replaced that with units.gridUnit, which is DPI aware.

Thank you for making this plasmoid.