### PR TITLE
Suppress incorrect MPRIS SetPosition calls on loading new media

### DIFF
--- a/org.kde.plasma.volumewin7mixer/package/contents/ui/MediaController.qml
+++ b/org.kde.plasma.volumewin7mixer/package/contents/ui/MediaController.qml
@@ -171,7 +171,6 @@ Item {
                 // console.log('onValueChanged skipped')
             }
         }
-        maximumValue: mpris2Source.length
         onMaximumValueChanged: mpris2Source.retrievePosition()
 
         Connections {
@@ -185,6 +184,11 @@ Item {
                     seekSlider.value = mpris2Source.position
                     mediaController.disablePositionUpdate = false
                 }
+            }
+            onLengthChanged: {
+                mediaController.disablePositionUpdate = true
+                seekSlider.maximumValue = mpris2Source.length
+                mediaController.disablePositionUpdate = false
             }
         }
 


### PR DESCRIPTION
In order to tell between user created slider valueChanged events and synthetic ones the code has a disablePositionUpdate flag which is set when updating the value.

setting Slider.maximumValue implicitly will also change value, so it needs the same logic.

This fixes a bug where opening a new media file will resume at the point where a previous media file left off.