### PR TITLE
Expand list of calendars in add-popup 

### DIFF
--- a/org.kde.plasma.eventcalendar/package/contents/ui/PopupView.qml
+++ b/org.kde.plasma.eventcalendar/package/contents/ui/PopupView.qml
@@ -347,7 +347,7 @@ Item {
                         var list = []
                         var selectedIndex = 0;
                         calendarList.forEach(function(calendar){
-                            if (calendar.accessRole == 'owner') {
+                            if (calendar.accessRole == 'writer' || calendar.accessRole == 'owner') {
                                 if (plasmoid.configuration.agenda_newevent_remember_calendar && calendar.id === plasmoid.configuration.agenda_newevent_last_calendar_id) {
                                     selectedIndex = list.length; // index after insertion
                                 }


### PR DESCRIPTION
I share a family calendar and I needed to include external calendars where the current user has 'writer' role, not just 'owner'. I thought this may be useful for other users too.